### PR TITLE
update lidar/proximity ipu to handle sonar data

### DIFF
--- a/src/ipu/source/lidar.py
+++ b/src/ipu/source/lidar.py
@@ -41,9 +41,14 @@ def get_and_translate():
             # print("time_increment:", message.time_increment)
             # print("-----")
 
-            detections = proximity.detections_to_coords(message.ranges)
+            # differentiate between LIDAR/SONAR data
+            try:
+                detections = proximity.lidar_to_coords(message.ranges)
+            except AttributeError:
+                detections = proximity.sonar_to_coords(message)
+
             neurons = proximity.coords_to_neuron_ids(
-                detections, cortical_area='proximity'
+                    detections, cortical_area='proximity'
             )
             # TODO: Add proximity feeder function in fcl_injector
             runtime_data.fcl_queue.put({'proximity': set(neurons)})


### PR DESCRIPTION
- checks if zmq message is from turtlebot vs. sonar sensor in the lidar source IPU, then calls the appropriate function in proximity processor IPU for conversion to neuronal activity

- data coming from HC-SR04 sensor was not reaching FEAGI because the proximity IPU processor was configured to receive turtlebot data only 

- closes #32 