### PR TITLE
Fix version check to allow same semantic version with beta suffix

### DIFF
--- a/.github/workflows/staging-pr.yml
+++ b/.github/workflows/staging-pr.yml
@@ -118,9 +118,12 @@ jobs:
         # Check that PR semantic version is > main semantic version
         # NOTE: Allow transition from Python 2.x.x to Rust 0.x.x series
         # Main branch still has Python 2.x.x version, Rust starts at 0.x.x
-        # TODO: Re-enable strict version check once main branch is updated to Rust versioning
+        # Also allow same semantic version if PR has beta suffix (for staging beta releases)
         if [[ "$MAIN_SEMANTIC" =~ ^2\. ]] && [[ "$CURRENT_SEMANTIC" =~ ^0\. ]]; then
           echo "ℹ️  Allowing transition from Python version ($MAIN_SEMANTIC) to Rust version ($CURRENT_SEMANTIC)"
+        elif [ "$CURRENT_SEMANTIC" = "$MAIN_SEMANTIC" ] && [ "$CURRENT_BETA" -ge 1 ]; then
+          # Same semantic version with beta suffix is allowed (for staging beta releases)
+          echo "ℹ️  Allowing same semantic version with beta suffix: $CURRENT_SEMANTIC-beta.$CURRENT_BETA"
         else
           HIGHER_SEMANTIC=$(printf '%s\n%s\n' "$MAIN_SEMANTIC" "$CURRENT_SEMANTIC" | sort -V | tail -n1)
           if [ "$HIGHER_SEMANTIC" != "$CURRENT_SEMANTIC" ] || [ "$CURRENT_SEMANTIC" = "$MAIN_SEMANTIC" ]; then
@@ -195,3 +198,4 @@ jobs:
     
     - name: Run Clippy (lib and tests only)
       run: cargo clippy --workspace --lib --tests -- -D warnings
+


### PR DESCRIPTION
- Allow PRs with same semantic version as main when PR has beta suffix
- This enables staging beta releases (0.0.1-beta.1) when main is at 0.0.1
- Fixes CI error: 'PR semantic version must be greater than main version'

This fix is needed in staging branch because pull_request_target workflows run from the base branch (staging), not the PR branch.